### PR TITLE
RichTextBlock Action added for the markdown formatter

### DIFF
--- a/source/community/reactnative/src/components/elements/label.js
+++ b/source/community/reactnative/src/components/elements/label.js
@@ -40,7 +40,8 @@ export class Label extends React.Component {
 				defaultStyles={[receivedStyle, computedStyle]}
 				numberOfLines={numberOfLines}
 				text={formattedText}
-				onDidLayout={onDidLayout} />
+				onDidLayout={onDidLayout}
+				onClick={() => { this.props.onClick && this.props.onClick() }} />
 		)
 	}
 

--- a/source/community/reactnative/src/components/elements/label.js
+++ b/source/community/reactnative/src/components/elements/label.js
@@ -34,14 +34,17 @@ export class Label extends React.Component {
 
 		// number of lines
 		let numberOfLines = wrap ? (maxLines != undefined ? maxLines : 0) : 1;
-
+		let clickProps;
+		if (this.props.onClick) {
+			clickProps = { onClick: this.props.onClick }
+		}
 		return (
 			<MarkDownFormatter
 				defaultStyles={[receivedStyle, computedStyle]}
 				numberOfLines={numberOfLines}
 				text={formattedText}
 				onDidLayout={onDidLayout}
-				onClick={() => { this.props.onClick && this.props.onClick() }} />
+				{...clickProps} />
 		)
 	}
 

--- a/source/community/reactnative/src/components/elements/rich-text-block.js
+++ b/source/community/reactnative/src/components/elements/rich-text-block.js
@@ -54,9 +54,9 @@ export class RichTextBlock extends React.Component {
      * @param {object} textRun - text run in the paragraph
      * @returns {object} constructed select Action component
      */
-    addActionElement = (textRun) => {
+    addActionElement = (textRun, index) => {
         return (
-            <Text onPress={() => { (HostConfigManager.supportsInteractivity() === false) ? null : this.onClickHandle(textRun.selectAction) }}>
+            <Text key={"text-wrapper" + index} onPress={() => { this.onClickHandle(textRun.selectAction) }}>
                 <Label
                     text={textRun.text}
                     size={textRun.size}
@@ -98,7 +98,7 @@ export class RichTextBlock extends React.Component {
                 index > 0 && textRunElements.push(<Text key={"white-sapce-text" + index}>{" "}</Text>);
                 let textRunStyle = textRun.highlight ? [styles.text, { backgroundColor: this.hostConfig.richTextBlock.highlightColor }] : styles.text;
                 textRunElements.push(
-                    textRun.selectAction ? this.addActionElement(textRun) :
+                    textRun.selectAction ? this.addActionElement(textRun, index) :
                         <Label
                             key={Constants.TextRunString + index}
                             text={textRun.text}

--- a/source/community/reactnative/src/components/elements/rich-text-block.js
+++ b/source/community/reactnative/src/components/elements/rich-text-block.js
@@ -66,7 +66,8 @@ export class RichTextBlock extends React.Component {
                     wrap={textRun.wrap}
                     align={textRun.horizontalAlignment}
                     maxLines={textRun.maxLines}
-                    style={styles.text} />
+                    style={styles.text}
+                    onClick={() => this.onClickHandle(textRun.selectAction)} />
             </Text>
         );
     }

--- a/source/community/reactnative/src/utils/markdown-formatter.js
+++ b/source/community/reactnative/src/utils/markdown-formatter.js
@@ -373,6 +373,10 @@ export default class MarkdownFormatter extends React.PureComponent {
 	 */
 	addOnPress = (url) => {
 		if (!url) {
+			//Check for rich-text-block textRun action
+			if (this.props.onClick) {
+				this.props.onClick()
+			}
 			return null;
 		} else {
 			Linking.canOpenURL(url).then(supported => {

--- a/source/community/reactnative/src/visualizer/payloads/payloads/RichTextBlock.json
+++ b/source/community/reactnative/src/visualizer/payloads/payloads/RichTextBlock.json
@@ -12,7 +12,7 @@
                     "inlines": [
                         {
                             "type": "TextRun",
-                            "text": "The Huffington Post",
+                            "text": "**The Huffington Post**",
                             "color": "good",
                             "selectAction": {
                                 "type": "Action.Submit",
@@ -23,7 +23,12 @@
                         {
                             "type": "TextRun",
                             "text": "5/23/2016",
-                            "color": "good"
+                            "color": "good",
+                            "selectAction": {
+                                "type": "Action.Submit",
+                                "title": "cool link",
+                                "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+                            }
                         },
                         {
                             "type": "TextRun",
@@ -40,12 +45,17 @@
                     "inlines": [
                         {
                             "type": "TextRun",
-                            "text": "Weather in",
-                            "color": "good"
+                            "text": "[Weather in](http://google.com)",
+                            "color": "good",
+                            "selectAction": {
+                                "type": "Action.OpenUrl",
+                                "title": "5/23/2016",
+                                "url": "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+                            }
                         },
                         {
                             "type": "TextRun",
-                            "text": "Chennai on",
+                            "text": "**Chennai on**",
                             "selectAction": {
                                 "type": "Action.OpenUrl",
                                 "title": "5/23/2016",


### PR DESCRIPTION
Worked to resolve the issue: #88
RichTextBlock Action added in the markdown format

Steps to test the PR:
1.  Launch the App.
2.  Navigate to "RichTextBlock.json" from the visualiser.
3.  Expected: The Inline text colours, Inline actions and Inline highlighting should be proper.