### PR TITLE
Updated font weight default to Bounding box

### DIFF
--- a/source/pic2card/mystique/config.py
+++ b/source/pic2card/mystique/config.py
@@ -60,7 +60,7 @@ FONT_SPEC_REGISTRY = {
     "font_bbox": "mystique.font_properties.FontPropBoundingBox"
 }
 # active font prop pipelne
-ACTIVE_FONTSPEC_NAME = "font_morph"
+ACTIVE_FONTSPEC_NAME = "font_bbox"
 
 # image detection swtiching paramater
 # On True [ uses custom image pipeline for image objects]

--- a/source/pic2card/mystique/extract_properties.py
+++ b/source/pic2card/mystique/extract_properties.py
@@ -218,7 +218,7 @@ class TextBoxProperty(BaseExtractProperties, FontColor):
             ),
             "data": data,
             "size": font_spec.get_size(image, coords, img_data=image_data),
-            "weight": font_spec.get_weight(image, coords),
+            "weight": font_spec.get_weight(image, coords, img_data=image_data),
             "color": self.get_colors(image, coords)
 
         }

--- a/source/pic2card/mystique/extract_properties.py
+++ b/source/pic2card/mystique/extract_properties.py
@@ -69,8 +69,8 @@ class BaseExtractProperties(AbstractBaseExtractProperties):
         img_data = pytesseract.image_to_data(
             cropped_image, lang="eng", config="--psm 6",
             output_type=Output.DICT)
-        text_list = ' '.join(img_data['text']).split()
-        extracted_text = ' '.join(text_list)
+        text_list = filter(None, img_data['text'])
+        extracted_text = ' '.join(text_list).lstrip("#-_*~").strip()
         return extracted_text, img_data
 
 

--- a/source/pic2card/mystique/font_properties.py
+++ b/source/pic2card/mystique/font_properties.py
@@ -40,7 +40,8 @@ class FontPropBoundingBox(AbstractFontSizeAndWeight):
                                           img_data['width'][i],
                                           img_data['height'][i])
                 # h = text_size_processing(img_data['text'][i], h)
-
+                # Approximate character width
+                char_w = char_w/len(img_data['text'][i])
                 box_height.append(char_h)
                 box_width.append(char_w)
         # passing box_width for the get_weight method


### PR DESCRIPTION
Implementation uses the default method of finding font weight using the bounding box width from pytessaract api.