### PR TITLE
Dependency issue fixes

### DIFF
--- a/.github/workflows/pic2card_build.yml
+++ b/.github/workflows/pic2card_build.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6]
+        python-version: [3.7]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/source/pic2card/commands/generate_card_using_python_client.py
+++ b/source/pic2card/commands/generate_card_using_python_client.py
@@ -6,7 +6,6 @@ python generate_card_using_python_client.py --image_path=/image_path \
     --api_url=url_of_the_service
 """
 import argparse
-import json
 import base64
 from mystique.utils import send_json_payload
 

--- a/source/pic2card/commands/generate_card_using_python_client.py
+++ b/source/pic2card/commands/generate_card_using_python_client.py
@@ -8,9 +8,10 @@ python generate_card_using_python_client.py --image_path=/image_path \
 import argparse
 import json
 import base64
+from mystique.utils import send_json_payload
 
 
-def main(image_path=None, api_url=None, card_format=None):
+def main(image_path=None, api_server=None, card_format=None):
     """
     Predict the card using python client
 
@@ -18,22 +19,22 @@ def main(image_path=None, api_url=None, card_format=None):
     @param api_url: url of the prediction service
     """
     base64_string = ""
+    api_path = "/predict_json"
     with open(image_path, "rb") as image_file:
         base64_string = base64.b64encode(image_file.read()).decode()
     if card_format:
-        response = requests.post(api_url,
-                                 data=json.dumps({"image": base64_string}),
-                                 headers={"Content-Type": "application/json"},
-                                 params={"format": card_format})
+        response = send_json_payload(api_path,
+                                     body={"image": base64_string},
+                                     host_port=api_server,
+                                     url_params={"format": card_format})
     else:
-        response = requests.post(api_url,
-                                 data=json.dumps({"image": base64_string}),
-                                 headers={"Content-Type": "application/json"})
+        response = send_json_payload(api_path,
+                                     body={"image": base64_string},
+                                     host_port=api_server)
 
-    print(json.dumps(response.json().get("card_json", ""), indent=2))
+    print(response.get("card_json", ""))
     if card_format:
-        print(json.dumps(response.json().get("template_data_payload", ""),
-                         indent=2))
+        print(response.get("template_data_payload", ""))
 
 
 if __name__ == "__main__":
@@ -41,13 +42,13 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Predict the Card Json")
     parser.add_argument("--image_path", required=True,
                         help="Enter Image path")
-    parser.add_argument("--api_url", required=True,
-                        help="Enter Service URL")
+    parser.add_argument("--api_server", required=True,
+                        help="Enter the api server host and port")
     parser.add_argument("--card_format",
                         help="Enter 'template' if card template data \
                               payload is needed",
                         default=None)
     args = parser.parse_args()
     main(image_path=args.image_path,
-         api_url=args.api_url,
+         api_server=args.api_server,
          card_format=args.card_format)

--- a/source/pic2card/commands/generate_card_using_python_client.py
+++ b/source/pic2card/commands/generate_card_using_python_client.py
@@ -8,7 +8,6 @@ python generate_card_using_python_client.py --image_path=/image_path \
 import argparse
 import json
 import base64
-import requests
 
 
 def main(image_path=None, api_url=None, card_format=None):

--- a/source/pic2card/mystique/predict_card.py
+++ b/source/pic2card/mystique/predict_card.py
@@ -16,7 +16,7 @@ from mystique.ac_export.card_template_data import DataBinding
 from mystique.extract_properties import CollectProperties
 from mystique.image_extraction import ImageExtraction
 from mystique.font_properties import classify_font_weights
-from mystique.utils import get_property_method
+from mystique.utils import get_property_method, send_json_payload
 from mystique.card_layout import row_column_group
 from mystique.card_layout import bbox_utils
 from mystique.ac_export import adaptive_card_export
@@ -121,18 +121,23 @@ class PredictCard:
 
     def tf_serving_main(self, bs64_img: str, tf_server: str, model_name: str,
                         card_format: str = None) -> Dict:
-        tf_uri = os.path.join(tf_server,
-                              f"v1/models/{model_name}:predict")
+        """
+        Do model inference using TF-Serve service.
+        """
+
+        api_path = "v1/models/{model_name}:predict"
         payloads = {
             "signature_name": "serving_default",
             "instances": [
                 {"b64": bs64_img}
             ]
         }
-
         # Hit the tf-serving and get the prediction
-        response = requests.post(tf_uri, json=payloads)
-        pred_res = json.loads(response.content)["predictions"][0]
+        response = send_json_payload(api_path,
+                                     body=payloads,
+                                     host_port=tf_server)
+
+        pred_res = response["predictions"][0]
 
         filtered_res = {}
         for key_col in ["detection_boxes", "detection_scores",

--- a/source/pic2card/mystique/predict_card.py
+++ b/source/pic2card/mystique/predict_card.py
@@ -9,7 +9,6 @@ from typing import Dict, List, Tuple
 
 import cv2
 import numpy as np
-import requests
 from PIL import Image
 from mystique import config
 from mystique.card_layout.arrange_card import CardArrange

--- a/source/pic2card/mystique/predict_card.py
+++ b/source/pic2card/mystique/predict_card.py
@@ -2,8 +2,6 @@
 
 import base64
 import io
-import json
-import os
 import uuid
 from typing import Dict, List, Tuple
 

--- a/source/pic2card/mystique/utils.py
+++ b/source/pic2card/mystique/utils.py
@@ -1,6 +1,9 @@
 import time
 import io
 import re
+import json
+import http.client
+import urllib
 from typing import Optional, Dict
 import glob
 import xml.etree.ElementTree as Et
@@ -174,3 +177,23 @@ def text_size_processing(text: str, height: int):
     if (match or text[0].isupper()):
         height -= 2
     return height
+
+
+def send_json_payload(path: str, body: Dict, host_port: str,
+                      method: str = "POST",
+                      url_params: Optional[Dict] = None) -> Dict:
+    """
+    Send Json payload via http post method.
+
+    @param path: API path, eg; /predict_json
+    @param body: Request payload
+    @param host_port: Host and port of the api server eg; localhost:5050
+    @param method: Http request method.
+    """
+    headers = {"Content-Type": "application/json"}
+    if url_params:
+        path += "?" + urllib.parse.urlencode(url_params)
+    conn = http.client.HTTPConnection(host_port)
+    conn.request(method, path, json.dumps(body), headers)
+    response = json.loads(conn.getresponse().read())
+    return response

--- a/source/pic2card/requirements/requirements.txt
+++ b/source/pic2card/requirements/requirements.txt
@@ -2,12 +2,11 @@
 #--use-feature=2020-resolver
 flask==1.1.1
 flask_restplus==0.13.0
-flask-cors==3.0.8
+flask-cors==3.0.9
 Werkzeug==0.16.1
 Pillow==7.1.2
 opencv-python==3.4.9.33
 pytesseract==0.3.4
-requests==2.23.0
 gunicorn==20.0.4
 pandas==1.0.4
 matplotlib==3.2.1

--- a/source/pic2card/tests/base_test_class.py
+++ b/source/pic2card/tests/base_test_class.py
@@ -1,6 +1,11 @@
 import os
 import unittest
 import time
+from typing import Dict, List
+import numpy as np
+import cv2
+from PIL import Image
+
 from tests.utils import (
     img_to_base64,
     headers,
@@ -8,7 +13,14 @@ from tests.utils import (
     payload_data_some_string,
     generate_base64,
 )
+
 from app.api import app
+from mystique.predict_card import PredictCard
+from mystique.extract_properties import CollectProperties
+from mystique.card_layout.arrange_card import CardArrange
+from mystique.utils import load_od_instance
+
+curr_dir = os.path.dirname(__file__)
 
 
 class BaseAPITest(unittest.TestCase):
@@ -32,3 +44,63 @@ class BaseAPITest(unittest.TestCase):
         """ To get the elapsed time for each test """
         elapsed = time.time() - self._started_at
         print('{} ({}s)'.format(self.id(), round(elapsed, 2)))
+
+
+class TestUtil:
+    def collect_json_objects(self, image: Image,
+                             model_instance: PredictCard) -> Dict:
+        """
+        Returns the dict of design objects collected from the prediction
+        @param image: input PIL image
+        @param model_instance: model instance object
+        @return: dict of design objects
+        """
+        image = image.convert("RGB")
+        image_np = np.asarray(image)
+        image_np = cv2.cvtColor(image_np, cv2.COLOR_RGB2BGR)
+        output_dict = model_instance.od_model.get_objects(
+            image_np=image_np, image=image
+        )
+        return model_instance.collect_objects(output_dict=output_dict,
+                                              pil_image=image)
+
+    def collect_image_sizes(self, json_objects: Dict, image: Image) -> List:
+        """
+        Returns the list of extracted image object sizes of the input image
+        @param json_objects: dict of design objects
+        @param image: input PIL image
+        @return: list of image object sizes
+        """
+        collect_properties = CollectProperties(image)
+        image_objects = [image_object for image_object in
+                         json_objects["objects"]
+                         if image_object["object"] == "image"]
+        for design_object in image_objects:
+            property_object = getattr(collect_properties,
+                                      design_object.get("object"))
+            property_element = property_object(image,
+                                               design_object.get("coords"))
+            design_object.update(property_element)
+        return [design_object.get("size", "") for design_object in
+                image_objects]
+
+
+class BaseSetUpClass(unittest.TestCase):
+    """
+    Base setup class for the tests, contains json objects collected
+    for a test image
+    """
+
+    def setUp(self):
+        self.image_path = os.path.join(
+            curr_dir, "../tests/test_images/test01.png")
+        self.test_util = TestUtil()
+        self.model_instance = load_od_instance()
+        self.model_instance = PredictCard(self.model_instance)
+
+        self.image = Image.open(self.image_path)
+        self.json_objects, _ = self.test_util.collect_json_objects(
+            self.image, self.model_instance)
+        self.test_coord1 = self.json_objects['objects'][0].get("coords", [])
+        self.test_coord2 = self.json_objects['objects'][1].get("coords", [])
+        self.card_arrange = CardArrange()

--- a/source/pic2card/tests/base_test_class.py
+++ b/source/pic2card/tests/base_test_class.py
@@ -47,6 +47,7 @@ class BaseAPITest(unittest.TestCase):
 
 
 class TestUtil:
+
     def collect_json_objects(self, image: Image,
                              model_instance: PredictCard) -> Dict:
         """

--- a/source/pic2card/tests/test_layout.py
+++ b/source/pic2card/tests/test_layout.py
@@ -1,6 +1,3 @@
-import os
-from typing import Dict, List
-
 from multiprocessing import Queue
 import unittest
 from unittest.mock import patch

--- a/source/pic2card/tests/test_layout.py
+++ b/source/pic2card/tests/test_layout.py
@@ -4,16 +4,10 @@ from typing import Dict, List
 from multiprocessing import Queue
 import unittest
 from unittest.mock import patch
-from PIL import Image
-import numpy as np
-import cv2
 
 from tests.test_variables import (debug_string_test, test_img_obj1,
                                   test_img_obj2, test_cset_obj1,
                                   test_cset_obj2)
-from mystique.utils import load_od_instance
-from mystique.predict_card import PredictCard
-from mystique.card_layout.arrange_card import CardArrange
 from mystique.extract_properties import CollectProperties
 from mystique.ac_export.adaptive_card_export import (
     AdaptiveCardExport)
@@ -24,68 +18,7 @@ from mystique.card_layout import row_column_group
 from mystique.card_layout.ds_helper import DsHelper
 from mystique.card_layout import bbox_utils
 
-curr_dir = os.path.dirname(__file__)
-
-
-class TestUtil:
-
-    def collect_json_objects(self, image: Image,
-                             model_instance: PredictCard) -> Dict:
-        """
-        Returns the dict of design objects collected from the prediction
-        @param image: input PIL image
-        @param model_instance: model instance object
-        @return: dict of design objects
-        """
-        image = image.convert("RGB")
-        image_np = np.asarray(image)
-        image_np = cv2.cvtColor(image_np, cv2.COLOR_RGB2BGR)
-        output_dict = model_instance.od_model.get_objects(
-            image_np=image_np, image=image
-        )
-        return model_instance.collect_objects(output_dict=output_dict,
-                                              pil_image=image)
-
-    def collect_image_sizes(self, json_objects: Dict, image: Image) -> List:
-        """
-        Returns the list of extracted image object sizes of the input image
-        @param json_objects: dict of design objects
-        @param image: input PIL image
-        @return: list of image object sizes
-        """
-        collect_properties = CollectProperties(image)
-        image_objects = [image_object for image_object in
-                         json_objects["objects"]
-                         if image_object["object"] == "image"]
-        for design_object in image_objects:
-            property_object = getattr(collect_properties,
-                                      design_object.get("object"))
-            property_element = property_object(image,
-                                               design_object.get("coords"))
-            design_object.update(property_element)
-        return [design_object.get("size", "") for design_object in
-                image_objects]
-
-
-class BaseSetUpClass(unittest.TestCase):
-    """
-    Base setup class for the tests, contains json objects collected
-    for a test image
-    """
-
-    def setUp(self):
-        self.image_path = os.path.join(
-            curr_dir, "../tests/test_images/test01.png")
-        self.test_util = TestUtil()
-        self.model_instance = load_od_instance()
-        self.model_instance = PredictCard(self.model_instance)
-
-        self.image = Image.open(self.image_path)
-        self.json_objects, _ = self.test_util.collect_json_objects(
-            self.image, self.model_instance)
-        self.test_coord1 = self.json_objects['objects'][0].get("coords", [])
-        self.test_coord2 = self.json_objects['objects'][1].get("coords", [])
-        self.card_arrange = CardArrange()
+from .base_test_class import BaseSetUpClass
 
 
 class TestIOU(BaseSetUpClass):
@@ -108,6 +41,7 @@ class TestIOU(BaseSetUpClass):
                                                              self.image)
         self.assertEqual(extracted_sizes, ["Small", "Small"])
 
+    @patch('mystique.config.NEW_LAYOUT_STRUCTURE', False)
     def test_build_card_json(self):
         """
         Tests the length of the card json and the


### PR DESCRIPTION
- Removed "requests" library as its sub-dependency has MPL2.0 license.
- Updated the areas where requests library are being used with standard HTTP client provided by the python
- Fixed the test discovery issue, as a few of the tests aren't running on actions due to filename issue.